### PR TITLE
feat(style): adopt Inter font and mirror MetaMask typography

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');
+
 :root {
   --solana-purple: #9945FF;
   --solana-green: #14F195;
@@ -23,7 +25,7 @@ body {
 body {
   color: #1a1a1a;
   background: #ffffff;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -36,7 +38,7 @@ a {
   transition: opacity 0.2s ease;
 }
 
-a:hover {
+ a:hover {
   opacity: 0.8;
 }
 
@@ -63,3 +65,15 @@ a:hover {
   }
 }
 
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+}
+
+h1 { font-weight: 800; letter-spacing: -0.02em; }
+h2 { font-weight: 700; letter-spacing: -0.01em; }
+h3 { font-weight: 700; letter-spacing: -0.01em; }
+h4 { font-weight: 700; letter-spacing: -0.01em; }
+h5 { font-weight: 600; letter-spacing: -0.01em; }
+h6 { font-weight: 600; letter-spacing: -0.01em; }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,8 +15,8 @@ module.exports = {
         'gradient-solana': 'linear-gradient(135deg, #9945FF 0%, #14F195 100%)',
         'gradient-solana-reverse': 'linear-gradient(135deg, #14F195 0%, #9945FF 100%)',
       },
+      fontFamily: { sans: ['Inter', 'ui-sans-serif', 'system-ui', '-apple-system', 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Arial', 'Noto Sans', 'Liberation Sans', 'sans-serif'] },
     },
   },
   plugins: [],
 }
-


### PR DESCRIPTION
## Summary\n- Adopt Inter font and mirror MetaMask typography with heavier headings and tighter tracking.\n\n## Changes\n- Global font loaded Inter from Google Fonts.\n- Tailwind config extended to set sans to Inter as default.\n- Typography tweaks: headings weights and letter-spacing.\n\n## How to review\n- Verify Inter loads and headings look correct across pages.\n\n## How to test\n- Run the app locally and compare typography with MetaMask.\n